### PR TITLE
Remove `async` attributes on `script` elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/handsontable/0.34.5/handsontable.css"/>
     <link rel="stylesheet" href="app.css"/>
 
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/handsontable/0.34.5/handsontable.js" async="false"></script>
-    <script type="text/javascript" src="app.js" async="false"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/handsontable/0.34.5/handsontable.js"></script>
+    <script type="text/javascript" src="app.js"></script>
 
     <title>MAT(仮)</title>
 </head>


### PR DESCRIPTION
## Background

* `async` attributes are boolean attributes.
  * See : https://html.spec.whatwg.org/multipage/scripting.html#attr-script-async
* About boolean attributes: “The presence of a boolean attribute on an element represents the true value, and the absence of the attribute represents the false value.” ( https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attribute )
  * `async="false"` is **NOT represents false value**.

## Problem occurred

* As both `script` element for handsontable.js and one for app.js have `async` attributes, app.js may be executed before handsontable.js are executed.
    * Then error occured : “ReferenceError: Handsontable is not defined”

## What this pull request do

* This pull request removes `async="false"`.
