### PR TITLE
Fix to paste only the contents of the table when pasting markdown table.

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,5 @@
 const SEPARATOR = '|';
+const HEADER_VALUE = ':-:';
 
 var data = [
     ['header1', 'header2'],
@@ -30,10 +31,48 @@ new Handsontable(container, {
         var alignRow = [SEPARATOR];
         var columnCount = coords[0].endCol - coords[0].startCol + 1;
         for (var i = 0; i < columnCount; i++) {
-            alignRow.push(':-:');
+            alignRow.push(HEADER_VALUE);
             alignRow.push(SEPARATOR);
         }
         // insert alignment info row
         data.splice(1, 0, alignRow);
+    },
+    beforePaste: function (data, coords) {
+        if (data.length === 1) {
+            return;
+        }
+        var headerRowOddNumberedColumns  = _.filter(data[1], function (v, k) {
+            return (k + 1) % 2 === 1;
+        });
+        var headerRowEvenNumberedColumns = _.filter(data[1], function (v, k) {
+            return (k + 1) % 2 === 0;
+        });
+
+        var isMarkdownTable =
+            _.every(headerRowOddNumberedColumns, function (v) {
+                return v === SEPARATOR;
+            })
+            && _.every(headerRowEvenNumberedColumns, function (v) {
+                return v === HEADER_VALUE;
+            });
+
+        if (!isMarkdownTable) {
+            return;
+        }
+
+        // retrieve markdown table value
+        for (var rowIndex = 0; rowIndex < data.length; rowIndex++) {
+            if (rowIndex === 1) {
+                continue;
+            }
+            var row = data[rowIndex];
+            var evenNumberedColumns = _.filter(row, function (v, k) {
+                return (k + 1) % 2 === 0;
+            });
+            // replace data
+            data[rowIndex] = evenNumberedColumns;
+        }
+        // remove header row
+        data.splice(1, 1);
     }
 });

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     <link rel="stylesheet" href="app.css"/>
 
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/handsontable/0.34.5/handsontable.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js"></script>
 
     <title>MAT(仮)</title>
 </head>


### PR DESCRIPTION
--
markdown tableのペースト時にテーブルの中身だけペーストするように修正

|	before	|	after	|
|	:-:	|	:-:	|
|	![before_c5dd856f5509caa9730a0233098abc5c](https://user-images.githubusercontent.com/926934/38567995-783dbc76-3d22-11e8-8cd5-bacd0db9d0e1.gif)	|	![after_13aae5f121bd50d1f15d6e15da42819b](https://user-images.githubusercontent.com/926934/38567996-7861e042-3d22-11e8-90e3-8875bfe8ee7f.gif)	|
